### PR TITLE
Prevent capturing wrong (2 as opposite to 1) version of fetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,12 +64,6 @@ function setupZeitFetch(fetch) {
 }
 
 function setup(fetch) {
-	if (!fetch) {
-		fetch = require('node-fetch');
-	}
-
-	fetch = fetch.default || fetch;
-
 	if (typeof fetch !== 'function') {
 		throw new Error(
 			"fetch() argument isn't a function; did you forget to initialize your @zeit/fetch import?"

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const toBuffer = require('raw-body');
 const listen = require('async-listen');
 const {createServer} = require('http');
-const fetch = require('../index')();
+const fetch = require('../index')(require('node-fetch'));
 
 exports.retriesUponHttp500 = async () => {
 	let i = 0;

--- a/test/index.js
+++ b/test/index.js
@@ -24,8 +24,8 @@ exports.retriesUponHttp500 = async () => {
 };
 
 exports.worksWithHttps = async () => {
-	const res = await fetch('https://zeit.co/?_now_no_cache=1');
-	assert.equal(res.headers.get('Server'), 'now');
+	const res = await fetch('https://zeit.co');
+	assert.equal(res.headers.get('Server'), 'cloudflare');
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,7 @@ exports.retriesUponHttp500 = async () => {
 };
 
 exports.worksWithHttps = async () => {
-	const res = await fetch('https://zeit.co');
+	const res = await fetch('https://zeit.co/?_now_no_cache=1');
 	assert.equal(res.headers.get('Server'), 'now');
 };
 


### PR DESCRIPTION
We must disallow capturing arbitrary `node-fetch` because it may be an incompatible version. For example:
https://github.com/zeit/metrics/blob/6340fdc22e59eebe10c60d4a050bbad10813dace/providers/librato.js#L4
In one service it takes `node-fetch@1`, in another `@2`. However `agentkeepalive` (https://github.com/zeit/metrics/blob/6340fdc22e59eebe10c60d4a050bbad10813dace/providers/librato.js#L6) is compatible with `@2` only (because of how headers are exposed https://github.com/node-modules/agentkeepalive/blob/3.4.1/lib/_http_agent.js#L337).