### PR TITLE
workaround for https://github.com/bitinn/node-fetch/issues/569

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,8 @@ function setup(fetch) {
 	}
 
 	fetch = fetch.default
-		? Object.assign(fetch.default, fetch) // combines Headers with "fetch.default" function
+		// combines "fetch.Headers" with "fetch.default" function
+		? Object.assign((...args) => fetch.default(...args), fetch.default, fetch)
 		: fetch;
 
 	if (typeof fetch !== 'function') {

--- a/index.js
+++ b/index.js
@@ -69,8 +69,7 @@ function setup(fetch) {
 	}
 
 	const fd = fetch.default;
-	fetch = fetch.default
-		// combines "fetch.Headers" with "fetch.default" function
+	fetch = fd // combines "fetch.Headers" with "fetch.default" function
 		? Object.assign((...args) => fd(...args), fd, fetch)
 		: fetch;
 

--- a/index.js
+++ b/index.js
@@ -68,9 +68,10 @@ function setup(fetch) {
 		fetch = require('node-fetch');
 	}
 
+	const fd = fetch.default;
 	fetch = fetch.default
 		// combines "fetch.Headers" with "fetch.default" function
-		? Object.assign((...args) => fetch.default(...args), fetch.default, fetch)
+		? Object.assign((...args) => fd(...args), fd, fetch)
 		: fetch;
 
 	if (typeof fetch !== 'function') {

--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ function setup(fetch) {
 
 	const fd = fetch.default;
 	if (fd) {
-		// combines "fetch.Headers" with "fetch.default" function
+		// combines "fetch.Headers" with "fetch.default" function.
+		// workaround for "fetch.Headers is not a constructor"
 		fetch = Object.assign((...args) => fd(...args), fd, fetch);
 	}
 

--- a/index.js
+++ b/index.js
@@ -68,7 +68,9 @@ function setup(fetch) {
 		fetch = require('node-fetch');
 	}
 
-	fetch = fetch.default || fetch;
+	fetch = fetch.default
+		? Object.assign(fetch.default, fetch) // combines Headers with "fetch.default" function
+		: fetch;
 
 	if (typeof fetch !== 'function') {
 		throw new Error(

--- a/index.js
+++ b/index.js
@@ -69,9 +69,10 @@ function setup(fetch) {
 	}
 
 	const fd = fetch.default;
-	fetch = fd // combines "fetch.Headers" with "fetch.default" function
-		? Object.assign((...args) => fd(...args), fd, fetch)
-		: fetch;
+	if (fd) {
+		// combines "fetch.Headers" with "fetch.default" function
+		fetch = Object.assign((...args) => fd(...args), fd, fetch);
+	}
 
 	if (typeof fetch !== 'function') {
 		throw new Error(


### PR DESCRIPTION
This transformation ensures that in webpacked state we have `fetch` as a function, and `fetch.Headers` as a constructor. Without this change, when webpacked, `fetch.Headers` is undefined after `fetch.default || fetch`.