### PR TITLE
Allow to pass agent options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,10 @@
-import { Agent } from 'http';
+import * as http from 'http';
+import * as https from 'http';
 import { Options as RetryOptions } from 'async-retry';
 import { Request, RequestInit, Response } from 'node-fetch';
 
 export type FetchOptions = RequestInit & {
-	agent?: Agent
+	agent?: https.Agent | http.Agent
 	retry?: RetryOptions
 }
 
@@ -12,5 +13,5 @@ export type Fetch = (
 	options?: FetchOptions
 ) => Promise<Response>;
 
-export default function SetupFetch(client?: Fetch): Fetch;
+export default function SetupFetch(client?: Fetch, agentOptions?: http.AgentOptions | https.AgentOptions): Fetch;
 export * from 'node-fetch';

--- a/index.js
+++ b/index.js
@@ -18,13 +18,13 @@ let defaultHttpGlobalAgent;
 let defaultHttpsGlobalAgent;
 
 function getDefaultHttpGlobalAgent(agentOpts) {
-	return defaultHttpGlobalAgent = defaultHttpGlobalAgent
-		|| (debug('init http agent'), new HttpAgent(agentOpts));
+	return defaultHttpGlobalAgent = defaultHttpGlobalAgent ||
+		(debug('init http agent'), new HttpAgent(agentOpts));
 }
 
 function getDefaultHttpsGlobalAgent(agentOpts) {
-	return defaultHttpsGlobalAgent = defaultHttpsGlobalAgent
-		|| (debug('init https agent'), new HttpsAgent(agentOpts));
+	return defaultHttpsGlobalAgent = defaultHttpsGlobalAgent ||
+		(debug('init https agent'), new HttpsAgent(agentOpts));
 }
 
 function getAgent(url, agentOpts) {


### PR DESCRIPTION
In order to figure out timers running after tests are done, we must be able to get an instance of `fetch` kere `keepAlive` is disabled. For this reason, this PR adds support to expose agent options to the main factory function so we can customize it.

It's a backward-compatible change.