### PR TITLE
Readable objects should be passed directly to fetch implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const {parse: parseUrl} = require('url');
+const {Readable} = require('stream');
 const HttpAgent = require('agentkeepalive');
 const debug = require('debug')('@zeit/fetch');
 const setupFetchRetry = require('@zeit/fetch-retry');
@@ -46,7 +47,7 @@ function setupZeitFetch(fetch, agentOpts = {}) {
 		opts.headers.set('host', opts.headers.get('host') || parseUrl(url).host);
 
 		// Convert Object bodies to JSON
-		if (opts.body && typeof opts.body === 'object' && !Buffer.isBuffer(opts.body)) {
+		if (opts.body && typeof opts.body === 'object' && !(Buffer.isBuffer(opts.body) || opts.body instanceof Readable)) {
 			opts.body = JSON.stringify(opts.body);
 			opts.headers.set('Content-Type', 'application/json');
 			opts.headers.set('Content-Length', Buffer.byteLength(opts.body));


### PR DESCRIPTION
Readable streams are part of the standard `fetch` interface and
thus should be handled there instead of serializing to JSON.